### PR TITLE
create pharod.rb

### DIFF
--- a/Formula/pharod.rb
+++ b/Formula/pharod.rb
@@ -1,10 +1,10 @@
 class Pharod < Formula
-  VERSION = "ea99cef8b2f6d962553d2d4431ad430111f18e6d"
+  VERSION = "1da9aa1a2d55412a7d262e6d22c032f051ac53b9"
   desc "Fork of madebymany project"
   homepage "https://github.com/ffxblue/pharod"
   url "https://github.com/ffxblue/pharod/archive/#{VERSION}.tar.gz"
   version "#{VERSION}"
-  sha256 "fe092af341acdbcbfbf7f754aada79c6e168c03202e7f1647694855c9fae7f11"
+  sha256 "38777071d28fa498959a41517bebc0dd0e5028f1c72a288d27dbd40a39a0663c"
   head "https://github.com/ffxblue/pharod.git", :branch => "master"
   depends_on "go" => :build
   depends_on "goenv" => :build

--- a/Formula/pharod.rb
+++ b/Formula/pharod.rb
@@ -1,0 +1,30 @@
+class Pharod < Formula
+  VERSION = "ea99cef8b2f6d962553d2d4431ad430111f18e6d"
+  desc "Fork of madebymany project"
+  homepage "https://github.com/ffxblue/pharod"
+  url "https://github.com/ffxblue/pharod/archive/#{VERSION}.tar.gz"
+  version "#{VERSION}"
+  sha256 "fe092af341acdbcbfbf7f754aada79c6e168c03202e7f1647694855c9fae7f11"
+  head "https://github.com/ffxblue/pharod.git", :branch => "master"
+  depends_on "go" => :build
+  depends_on "goenv" => :build
+  depends_on "glide" => :build
+
+  def install
+    Dir.mktmpdir('pharod') do |tmp_dir|
+      ENV['GOPATH'] = tmp_dir
+      ENV['PATH'] = [File.join(tmp_dir, 'bin'), ENV['PATH']].join(':')
+      pkg_dir = File.join(tmp_dir, 'src/github.com/ffxblue/pharod')
+      system 'mkdir', '-p', File.dirname(pkg_dir)
+      system 'ln', '-s', Dir.pwd, pkg_dir
+      system "cd #{pkg_dir} && goenv install --skip-existing $(cat .go-version)"
+      system "cd #{pkg_dir} && glide install"
+      system "cd #{pkg_dir} && go build -ldflags -s"
+      system "cd #{pkg_dir}/pharodctl && go build -ldflags -s"
+      bin.install "pharod"
+      bin.install "pharodctl/pharodctl"
+      bin.install "pharod-start"
+      bin.install "pharod-stop"
+    end
+  end
+end


### PR DESCRIPTION
Version is now based on master of https://github.com/ffxblue/pharod.
Initial commit was based off branch ID.

This will build the project on `brew install ffxblue/pharod`, which is slow and far from ideal. _Slightly_ better than the old Ansible way though, as we only keep the artefacts, not the whole project.

If we intend to keep using `pharod` for much longer, we should:
1. Move the https://github.com/ffxblue/pharod/ fork to BB
2. Hook project up to pipeline and build there instead (see cli-bluestrap as example)

But this should work for now.